### PR TITLE
Fix union type syntax for Python <3.10

### DIFF
--- a/sistema_triagem_sus_completo/triagem_sus/models/diabetes_risk.py
+++ b/sistema_triagem_sus_completo/triagem_sus/models/diabetes_risk.py
@@ -1,6 +1,7 @@
 import os
 import pickle
 from dataclasses import dataclass
+from typing import Optional
 
 import numpy as np
 from sklearn.datasets import load_diabetes
@@ -13,8 +14,8 @@ from sklearn.preprocessing import StandardScaler
 class DiabetesRiskModel:
     """Modelo simples para previsão de risco de diabetes."""
 
-    model: LogisticRegression | None = None
-    scaler: StandardScaler | None = None
+    model: Optional[LogisticRegression] = None
+    scaler: Optional[StandardScaler] = None
 
     def train(self) -> float:
         """Treina o modelo usando o dataset de exemplo do scikit-learn."""


### PR DESCRIPTION
## Summary
- fix union type syntax in `DiabetesRiskModel` so it runs on Python versions prior to 3.10

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d81509ed0832bb4fac6738008980c