### PR TITLE
Add pneumonia detection model and training UI

### DIFF
--- a/sistema_triagem_sus_completo/triagem_sus/models/pneumonia_detector.py
+++ b/sistema_triagem_sus_completo/triagem_sus/models/pneumonia_detector.py
@@ -1,0 +1,73 @@
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+from torch import nn, optim
+from torch.utils.data import DataLoader
+from torchvision import datasets, models, transforms
+
+@dataclass
+class PneumoniaXRayModel:
+    """Detecção de pneumonia em raio-X usando transfer learning."""
+    model: Optional[nn.Module] = None
+    device: str = "cuda" if torch.cuda.is_available() else "cpu"
+
+    def train(self, data_dir: str = "data/chest_xray") -> float:
+        """Treina o modelo com o dataset Chest X-Ray Pneumonia."""
+        transform = transforms.Compose([
+            transforms.Resize((224, 224)),
+            transforms.ToTensor(),
+            transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+        ])
+        train_path = os.path.join(data_dir, "train")
+        val_path = os.path.join(data_dir, "val")
+        train_ds = datasets.ImageFolder(train_path, transform=transform)
+        val_ds = datasets.ImageFolder(val_path, transform=transform)
+        train_dl = DataLoader(train_ds, batch_size=16, shuffle=True)
+        val_dl = DataLoader(val_ds, batch_size=16)
+
+        base_model = models.resnet18(weights=models.ResNet18_Weights.DEFAULT)
+        for p in base_model.parameters():
+            p.requires_grad = False
+        num_ftrs = base_model.fc.in_features
+        base_model.fc = nn.Linear(num_ftrs, 2)
+        self.model = base_model.to(self.device)
+
+        criterion = nn.CrossEntropyLoss()
+        optimizer = optim.Adam(self.model.fc.parameters(), lr=1e-3)
+
+        self.model.train()
+        for epoch in range(1):
+            for imgs, labels in train_dl:
+                imgs, labels = imgs.to(self.device), labels.to(self.device)
+                optimizer.zero_grad()
+                outputs = self.model(imgs)
+                loss = criterion(outputs, labels)
+                loss.backward()
+                optimizer.step()
+
+        self.model.eval()
+        correct = 0
+        total = 0
+        with torch.no_grad():
+            for imgs, labels in val_dl:
+                imgs, labels = imgs.to(self.device), labels.to(self.device)
+                outputs = self.model(imgs)
+                _, preds = torch.max(outputs, 1)
+                correct += (preds == labels).sum().item()
+                total += labels.size(0)
+        acc = correct / total if total > 0 else 0
+        return acc
+
+    def save(self, path: str) -> None:
+        if self.model is None:
+            raise ValueError("Modelo não treinado")
+        torch.save(self.model.state_dict(), path)
+
+    def load(self, path: str) -> None:
+        base_model = models.resnet18(weights=models.ResNet18_Weights.DEFAULT)
+        num_ftrs = base_model.fc.in_features
+        base_model.fc = nn.Linear(num_ftrs, 2)
+        base_model.load_state_dict(torch.load(path, map_location=self.device))
+        self.model = base_model.to(self.device)

--- a/sistema_triagem_sus_completo/triagem_sus/requirements.txt
+++ b/sistema_triagem_sus_completo/triagem_sus/requirements.txt
@@ -11,3 +11,5 @@ seaborn==0.13.2
 python-dotenv==1.1.1
 requests==2.32.3
 
+torch==2.3.0
+torchvision==0.18.0

--- a/sistema_triagem_sus_completo/triagem_sus/web/templates/base.html
+++ b/sistema_triagem_sus_completo/triagem_sus/web/templates/base.html
@@ -27,6 +27,8 @@
                 <a class="nav-link" href="{{ url_for('triagem_form') }}">Nova Triagem</a>
                 <a class="nav-link" href="{{ url_for('fila_prioridade') }}">Fila</a>
                 <a class="nav-link" href="{{ url_for('dashboard') }}">Dashboard</a>
+                <a class="nav-link" href="{{ url_for('dados_diabetes') }}">Dados Diabetes</a>
+                <a class="nav-link" href="{{ url_for('retrain_models') }}">Treinar Modelos</a>
             </div>
         </div>
     </nav>

--- a/sistema_triagem_sus_completo/triagem_sus/web/templates/dados_diabetes.html
+++ b/sistema_triagem_sus_completo/triagem_sus/web/templates/dados_diabetes.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block title %}Dados do Modelo de Diabetes{% endblock %}
+{% block content %}
+<h3 class="mb-3">Amostra do Dataset de Diabetes</h3>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+        {% for col in columns %}
+            <th>{{ col }}</th>
+        {% endfor %}
+        </tr>
+    </thead>
+    <tbody>
+        {% for row in rows %}
+        <tr>
+            {% for val in row %}
+            <td>{{ val }}</td>
+            {% endfor %}
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/sistema_triagem_sus_completo/triagem_sus/web/templates/index.html
+++ b/sistema_triagem_sus_completo/triagem_sus/web/templates/index.html
@@ -17,6 +17,19 @@
     </div>
 </div>
 
+<div class="row mb-4">
+    <div class="col-md-6 text-center">
+        <a href="{{ url_for('fila_prioridade') }}" class="btn btn-outline-primary btn-lg w-75">
+            <i class="fas fa-list"></i> Fila de Pacientes
+        </a>
+    </div>
+    <div class="col-md-6 text-center">
+        <a href="{{ url_for('dados_diabetes') }}" class="btn btn-outline-secondary btn-lg w-75">
+            <i class="fas fa-database"></i> Dados do Modelo de Diabetes
+        </a>
+    </div>
+</div>
+
 <div class="row">
     <div class="col-md-4">
         <div class="card">

--- a/sistema_triagem_sus_completo/triagem_sus/web/templates/retrain.html
+++ b/sistema_triagem_sus_completo/triagem_sus/web/templates/retrain.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block title %}Treinar Modelos{% endblock %}
+{% block content %}
+<h3 class="mb-4">Treinamento dos Modelos</h3>
+<div class="d-grid gap-3 col-6 mx-auto">
+    <a href="{{ url_for('train_diabetes') }}" class="btn btn-primary">Re-treinar Modelo de Diabetes</a>
+    <a href="{{ url_for('train_pneumonia') }}" class="btn btn-secondary">Re-treinar Modelo de Pneumonia</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add convolutional pneumonia model with transfer learning
- create data preview and model retraining screens
- expose new routes for model training and dataset view
- update navigation and landing page links
- include torch dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d82a9e768832b8f4a1a44af0e2011