### PR TITLE
Improve error handling for pneumonia training dataset

### DIFF
--- a/sistema_triagem_sus_completo/triagem_sus/README.md
+++ b/sistema_triagem_sus_completo/triagem_sus/README.md
@@ -76,6 +76,18 @@ python data/generate_synthetic_data.py
 python models/ml_models.py
 ```
 
+5. (Opcional) Para treinar o detector de pneumonia, baixe o dataset
+   ["Chest X-Ray Images (Pneumonia)"](https://www.kaggle.com/paultimothymooney/chest-xray-pneumonia)
+   do Kaggle e extraia as pastas `train`, `val` e `test` em `data/chest_xray/`.
+   A estrutura final deve ficar assim:
+
+   ```
+   data/chest_xray/
+   ├── train/
+   ├── val/
+   └── test/
+   ```
+
 ## Uso
 
 ### 1. Agente Inteligente de Triagem

--- a/sistema_triagem_sus_completo/triagem_sus/models/pneumonia_detector.py
+++ b/sistema_triagem_sus_completo/triagem_sus/models/pneumonia_detector.py
@@ -22,6 +22,13 @@ class PneumoniaXRayModel:
         ])
         train_path = os.path.join(data_dir, "train")
         val_path = os.path.join(data_dir, "val")
+        if not os.path.isdir(train_path) or not os.path.isdir(val_path):
+            raise FileNotFoundError(
+                f"Pasta do dataset não encontrada em '{data_dir}'. "
+                "Baixe o conjunto 'Chest X-Ray Pneumonia' e coloque as "
+                "subpastas 'train' e 'val' nesse diretório."
+            )
+
         train_ds = datasets.ImageFolder(train_path, transform=transform)
         val_ds = datasets.ImageFolder(val_path, transform=transform)
         train_dl = DataLoader(train_ds, batch_size=16, shuffle=True)

--- a/sistema_triagem_sus_completo/triagem_sus/web/app.py
+++ b/sistema_triagem_sus_completo/triagem_sus/web/app.py
@@ -232,7 +232,11 @@ def train_diabetes():
 @app.route('/train/pneumonia')
 def train_pneumonia():
     data_dir = os.path.join(os.path.dirname(__file__), '..', 'data', 'chest_xray')
-    acc = pneumonia_model.train(data_dir)
+    try:
+        acc = pneumonia_model.train(data_dir)
+    except FileNotFoundError as e:
+        return jsonify({'error': str(e)}), 500
+
     path = os.path.join(os.path.dirname(__file__), '..', 'models', 'pneumonia_model.pt')
     pneumonia_model.save(path)
     return redirect(url_for('retrain_models'))


### PR DESCRIPTION
## Summary
- check that the chest X-ray dataset exists before training
- return a JSON error if the dataset is missing on the web route
- document how to obtain the dataset for pneumonia training

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d86dd19e8832ba66f8e185c6bc7ba