### PR TITLE
Improve verbose output during ML training

### DIFF
--- a/sistema_triagem_sus_completo/triagem_sus/models/diabetes_risk.py
+++ b/sistema_triagem_sus_completo/triagem_sus/models/diabetes_risk.py
@@ -19,22 +19,28 @@ class DiabetesRiskModel:
 
     def train(self) -> float:
         """Treina o modelo usando o dataset de exemplo do scikit-learn."""
+        print("Carregando dataset de diabetes...")
         data = load_diabetes()
         X = data.data[:, [0, 3]]  # age e blood pressure
         y = (data.target > np.median(data.target)).astype(int)
 
+        print("Dividindo dados em treino e teste...")
         X_train, X_test, y_train, y_test = train_test_split(
             X, y, test_size=0.2, random_state=42
         )
 
+        print("Normalizando dados...")
         self.scaler = StandardScaler()
         X_train_scaled = self.scaler.fit_transform(X_train)
         X_test_scaled = self.scaler.transform(X_test)
 
+        print("Treinando modelo de regressão logística...")
         self.model = LogisticRegression(max_iter=1000)
         self.model.fit(X_train_scaled, y_train)
 
+        print("Avaliando modelo...")
         acc = self.model.score(X_test_scaled, y_test)
+        print(f"Acurácia obtida: {acc:.4f}")
         return acc
 
     def save(self, path: str) -> None:

--- a/sistema_triagem_sus_completo/triagem_sus/models/ml_models.py
+++ b/sistema_triagem_sus_completo/triagem_sus/models/ml_models.py
@@ -90,7 +90,12 @@ class TriageMLModels:
     def train_models(self, X, y):
         """Treina todos os modelos"""
         print("\nDividindo dados em treino e teste...")
-        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42, stratify=y)
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=0.2, random_state=42, stratify=y
+        )
+        print(f"Amostras de treino: {X_train.shape[0]} / Amostras de teste: {X_test.shape[0]}")
+
+        print("Normalizando dados...")
         
         # Normalizar dados
         scaler = StandardScaler()
@@ -100,20 +105,33 @@ class TriageMLModels:
         
         # 1. Random Forest
         print("\nTreinando Random Forest...")
-        rf_model = RandomForestClassifier(n_estimators=100, random_state=42, max_depth=10)
+        rf_model = RandomForestClassifier(
+            n_estimators=100,
+            random_state=42,
+            max_depth=10,
+            verbose=1,
+        )
         rf_model.fit(X_train, y_train)
+        print("Random Forest treinado.")
         self.models['random_forest'] = rf_model
         
         # 2. Regressão Logística
         print("Treinando Regressão Logística...")
-        lr_model = LogisticRegression(random_state=42, max_iter=1000)
+        lr_model = LogisticRegression(random_state=42, max_iter=1000, verbose=1)
         lr_model.fit(X_train_scaled, y_train)
+        print("Regressão Logística treinada.")
         self.models['logistic_regression'] = lr_model
         
         # 3. Rede Neural (MLP)
         print("Treinando Rede Neural...")
-        mlp_model = MLPClassifier(hidden_layer_sizes=(100, 50), random_state=42, max_iter=500)
+        mlp_model = MLPClassifier(
+            hidden_layer_sizes=(100, 50),
+            random_state=42,
+            max_iter=500,
+            verbose=True,
+        )
         mlp_model.fit(X_train_scaled, y_train)
+        print("Rede Neural treinada.")
         self.models['neural_network'] = mlp_model
         
         # Avaliar modelos
@@ -128,22 +146,25 @@ class TriageMLModels:
         results = {}
         
         # Random Forest
+        print("\nAvaliando Random Forest...")
         rf_pred = self.models['random_forest'].predict(X_test)
         rf_accuracy = accuracy_score(y_test, rf_pred)
         results['random_forest'] = rf_accuracy
-        print(f"\nRandom Forest - Acurácia: {rf_accuracy:.4f}")
+        print(f"Acurácia: {rf_accuracy:.4f}")
         
         # Regressão Logística
+        print("\nAvaliando Regressão Logística...")
         lr_pred = self.models['logistic_regression'].predict(X_test_scaled)
         lr_accuracy = accuracy_score(y_test, lr_pred)
         results['logistic_regression'] = lr_accuracy
-        print(f"Regressão Logística - Acurácia: {lr_accuracy:.4f}")
+        print(f"Acurácia: {lr_accuracy:.4f}")
         
         # Rede Neural
+        print("\nAvaliando Rede Neural...")
         mlp_pred = self.models['neural_network'].predict(X_test_scaled)
         mlp_accuracy = accuracy_score(y_test, mlp_pred)
         results['neural_network'] = mlp_accuracy
-        print(f"Rede Neural - Acurácia: {mlp_accuracy:.4f}")
+        print(f"Acurácia: {mlp_accuracy:.4f}")
         
         # Melhor modelo
         best_model = max(results, key=results.get)
@@ -180,17 +201,22 @@ class TriageMLModels:
         
         # Salvar modelos
         for name, model in self.models.items():
-            with open(f'/home/ubuntu/triagem_sus/models/{name}_model.pkl', 'wb') as f:
+            path = f'/home/ubuntu/triagem_sus/models/{name}_model.pkl'
+            print(f'Salvando {name} em {path}...')
+            with open(path, 'wb') as f:
                 pickle.dump(model, f)
         
         # Salvar scalers e encoders
+        print('Salvando scalers...')
         with open('/home/ubuntu/triagem_sus/models/scalers.pkl', 'wb') as f:
             pickle.dump(self.scalers, f)
         
+        print('Salvando encoders...')
         with open('/home/ubuntu/triagem_sus/models/encoders.pkl', 'wb') as f:
             pickle.dump(self.encoders, f)
         
         # Salvar nomes das features
+        print('Salvando nomes das features...')
         with open('/home/ubuntu/triagem_sus/models/feature_names.json', 'w') as f:
             json.dump(self.feature_names, f)
         

--- a/sistema_triagem_sus_completo/triagem_sus/web/templates/train_result.html
+++ b/sistema_triagem_sus_completo/triagem_sus/web/templates/train_result.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block title %}Resultado do Treinamento{% endblock %}
+{% block content %}
+<h3 class="mb-4">Treinamento do Modelo {{ model }}</h3>
+<pre class="bg-light p-3" style="max-height: 400px; overflow-y: auto;">{{ logs|join('\n') }}</pre>
+<p><strong>Acurácia final:</strong> {{ "%.4f"|format(accuracy) }}</p>
+<a href="{{ url_for('retrain_models') }}" class="btn btn-primary mt-3">Voltar</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add sample counts and normalizing message when splitting data
- enable verbose mode for all models and print training/evaluation steps
- print file paths during save operations

## Testing
- `python -m py_compile sistema_triagem_sus_completo/triagem_sus/models/ml_models.py`
- `python -m py_compile sistema_triagem_sus_completo/triagem_sus/models/diabetes_risk.py`
- `python -m py_compile sistema_triagem_sus_completo/triagem_sus/models/pneumonia_detector.py`


------
https://chatgpt.com/codex/tasks/task_e_685d885f4344832b800bb34d9543a5f5