### PR TITLE
Adiciona cálculo de score de diabetes opcional na triagem

### DIFF
--- a/sistema_triagem_sus_completo/triagem_sus/models/diabetes_risk.py
+++ b/sistema_triagem_sus_completo/triagem_sus/models/diabetes_risk.py
@@ -17,6 +17,10 @@ class DiabetesRiskModel:
     model: Optional[LogisticRegression] = None
     scaler: Optional[StandardScaler] = None
 
+    def is_trained(self) -> bool:
+        """Indica se o modelo já foi treinado e possui scaler."""
+        return self.model is not None and self.scaler is not None
+
     def train(self) -> float:
         """Treina o modelo usando o dataset de exemplo do scikit-learn."""
         print("Carregando dataset de diabetes...")

--- a/sistema_triagem_sus_completo/triagem_sus/web/templates/fila.html
+++ b/sistema_triagem_sus_completo/triagem_sus/web/templates/fila.html
@@ -19,7 +19,13 @@
             <td>{{ item.patient_id }}</td>
             <td>{{ item.triage_result.risk_category }}</td>
             <td>{{ item.triage_result.priority }}</td>
-            <td>{{ "%.2f"|format(item.diabetes_score) }}</td>
+            <td>
+                {% if item.diabetes_score is not none %}
+                    {{ "%.2f"|format(item.diabetes_score) }}
+                {% else %}
+                    N/A
+                {% endif %}
+            </td>
         </tr>
         {% endfor %}
     </tbody>


### PR DESCRIPTION
## Summary
- implement `is_trained` in `DiabetesRiskModel`
- only compute diabetes score if the model is available
- avoid auto-training diabetes model when missing
- handle absence of diabetes model in patient explanation route
- show `N/A` in queue when score not computed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d90073e00832b8de047c6d893d979