### PR TITLE
Fix agent template formatting

### DIFF
--- a/sistema_triagem_sus_completo/triagem_sus/agents/intelligent_triage_agent.py
+++ b/sistema_triagem_sus_completo/triagem_sus/agents/intelligent_triage_agent.py
@@ -324,8 +324,8 @@ class IntelligentTriageAgent:
         """
         tools_str = "\n".join(f"{t.name}: {t.description}" for t in self.tools)
         tool_names = ", ".join(t.name for t in self.tools)
-        filled_template = template.format(tools=tools_str, tool_names=tool_names)
-        prompt = PromptTemplate.from_template(filled_template)
+        prompt = PromptTemplate.from_template(template)
+        prompt = prompt.partial(tools=tools_str, tool_names=tool_names)
 
         return create_react_agent(self.llm, self.tools, prompt)
     


### PR DESCRIPTION
## Summary
- fix agent template formatting by partializing the PromptTemplate instead of formatting the string directly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d9954b604832ba7263f2f2e28ce3b